### PR TITLE
Showing how to add a license

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,6 @@
 {
   "title": "How to tune your DOI record with Zenodo",
+  "license": "BSD-3-Clause",
   "creators": [
     {
       "name": "Castelao, Guilherme",

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Example
 The .zenodo.json in this repository is an actual example on how to write your descriptor.
 You can check the outcome result at https://doi.org/10.5281/zenodo.3981501
 
-title
+Title
 -----
 
 The title of the project. The equivalent of a title of an article.
@@ -37,6 +37,16 @@ ex.:
 
 "title": "How to tune your DOI record with Zenodo"
 
+
+License
+-------
+
+The license of the project. Check https://spdx.org/licenses/ for a list of
+licenses and their abbreviations.
+
+ex.:
+
+"license": "MIT"
 
 Contributors
 ------------

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,9 @@ ex.:
 License
 -------
 
-The license of the project. Check https://spdx.org/licenses/ for a list of
-licenses and their abbreviations.
+The license of the project. The https://choosealicense.com is a good reference
+when don't know what to use. Check https://spdx.org/licenses/ for a list of
+licenses and their identifiers.
 
 ex.:
 


### PR DESCRIPTION
There was no example of how to set up a license. If not defined, Zenodo defaults to CC.